### PR TITLE
Add reference for WP-CLI snippets

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@
 	- [Package discovery](#package-discovery)
 	- [Notable packages](#notable-packages)
 - [Tutorials & guides](#tutorials--guides)
+- [Contribute](#contribute)
 
 ## Official links
 

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ Websites, ebooks, PDFs, talks and slide shows about how to make the most out of 
 - [Controlling WordPress through the Command Line](https://wordpress.tv/2017/05/22/alain-schlesser-controlling-wordpress-through-the-command-line-introduction-to-wp-cli/) - Introductory talk that covers the very basics of the command line for people who never used the console before.
 - [WP Bullet WP-CLI Guides](https://guides.wp-bullet.com/category/wp-cli/) - Snippet-based guides that solve specific use cases.
 - [Siteground Webinar: Learn How WP-CLI Can Make Your Life Easier](https://www.youtube.com/watch?v=DlxbRYpZdQg) - Practical examples on how you can improve your workflows with WP-CLI.
+- [CaptainCore Cookbook](https://captaincore.io/cookbook/) - Collection of WP-CLI commands and bash scripts for automating WordPress maintenance.
 
 ## Contribute
 


### PR DESCRIPTION
Add link to personal collection of WP-CLI commands and bash scripts for automating WordPress maintenance.